### PR TITLE
fix: correct flat key display (Bb not BB) and Enter-to-confirm in modal

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -412,7 +412,6 @@ button.btn-danger:hover {
   font-family: var(--font-ui);
   font-size: var(--font-size-xs);
   font-weight: var(--font-weight-semibold);
-  text-transform: uppercase;
   letter-spacing: 0.05em;
   color: var(--color-text-muted);
   padding: var(--space-1) var(--space-3);

--- a/src/container/SongTextInput/ProcessChordLinesModal/index.tsx
+++ b/src/container/SongTextInput/ProcessChordLinesModal/index.tsx
@@ -1,5 +1,5 @@
 import Modal from '@/components/Modal';
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, KeyboardEvent } from 'react';
 
 interface ProcessChordLinesModalProps {
     isOpen: boolean;
@@ -12,14 +12,21 @@ const ProcessChordLinesModal: FunctionComponent<ProcessChordLinesModalProps> = (
     onClose,
     processChordLines,
 }) => {
+    const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            processChordLines();
+        }
+    };
+
     return (
         <Modal isOpen={isOpen} onClose={onClose}>
-            <div className="ProcessChordLinesModal">
+            <div className="ProcessChordLinesModal" onKeyDown={handleKeyDown}>
                 You entered a song with lines containing chords. Do you want to treat these lines as
                 chords?
                 <div className="ProcessChordLinesModalButtons">
                     <button onClick={onClose}>No, thanks</button>
-                    <button className="btn-primary" onClick={processChordLines}>
+                    <button className="btn-primary" onClick={processChordLines} autoFocus>
                         Yes
                     </button>
                 </div>


### PR DESCRIPTION
## Summary

- **#38 Bug fix:** Key badge displayed `BB` instead of `Bb` for flat keys because `.ResultKey` had `text-transform: uppercase` in CSS. Removed that rule — `Bb`, `Eb`, `Ab` etc. now render correctly.
- **#39 Improvement:** Pressing Enter/Return in the chord-extraction modal now confirms ("Yes"). Implemented via `onKeyDown` on the modal content div + `autoFocus` on the primary button.

## Test plan

- [ ] Open app, paste a song in Bb major, submit — key badge shows `Key: Bb` not `Key: BB`
- [ ] Paste a song with chord lines, press Enter in the modal — chords are extracted (same as clicking "Yes")
- [ ] Press Escape / click X / click "No, thanks" — modal closes without processing
- [ ] All 439 unit tests pass (`yarn test --watchAll=false`)
- [ ] All 42 E2E tests pass (`yarn playwright test`)
- [ ] Production build succeeds (`yarn build`)

## OpenSpec

These are isolated CSS and UX fixes with no impact on the canonical data model or parsing pipeline — no spec update required.

Closes #38
Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)
